### PR TITLE
DM Bot to share prayer anonymously

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -1,0 +1,8 @@
+module.exports = {
+	name: 'messageCreate',
+	execute(client, message) {
+        if (message.channel.type === "DM" && message.author.id !== client.user.id) {
+            return message.reply({ content: `${message.content} : ${message.author.id} : ${ client.user.id}` });
+        }
+	},
+};

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -1,8 +1,20 @@
 module.exports = {
 	name: 'messageCreate',
-	execute(client, message) {
+	async execute(client, guildId, message) {
+        let targetGuild = await client.guilds.fetch(guildId);
+        let prayerChannel = await targetGuild.channels.fetch()
+            .then(channels => {
+                const targetChannel = channels.find(channel => channel.name.toLowerCase() === "prayer-requests")
+                return targetChannel;
+            })
+
         if (message.channel.type === "DM" && message.author.id !== client.user.id) {
-            return message.reply({ content: `${message.content} : ${message.author.id} : ${ client.user.id}` });
+            if (prayerChannel) {
+                prayerChannel.send(`Prayer Request:\n${message.content}\n\nRequester wishes to remain anonymous`);
+                return message.reply('Saint Anonymous shared your prayer.');
+            } else {
+                return message.reply('Saint Anonymous cannot find the #prayer-channel. Please create one before sending another');
+            }
         }
 	},
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,15 @@ const fs = require('node:fs');
 const { Client, Collection, Intents } = require('discord.js');
 const { token } = require('./config.json');
 
-const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
+const client = new Client({ 
+	intents: [
+		Intents.FLAGS.GUILDS, 
+		Intents.FLAGS.DIRECT_MESSAGES
+	],
+	partials: [
+        'CHANNEL', // Required to receive DMs
+    ]
+});
 
 const eventFiles = fs.readdirSync('./events')
 	.filter(file => file.endsWith('.js'));

--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ for (const file of eventFiles) {
 	const event = require(`./events/${file}`);
 	if (event.once) {
 		client.once(event.name, (...args) => event.execute(...args));
+	} else if (event.name === 'messageCreate') {
+		let guild = JSON.parse(fs.readFileSync('config.json'));
+		client.on(event.name, async (...args) => await event.execute(client, guild['guildId'], ...args));
 	} else {
 		client.on(event.name, async (...args) => await event.execute(client, ...args));
 	}


### PR DESCRIPTION
You can DM the bot to share your prayer anonymously to the `#prayer-requests` channel.

If the channel doesn't exist, it'll let the requester know.

NOTE: it requires the config.json with the respective `guildId` the bot was added to. 